### PR TITLE
[Draft] Allow chaining numeric/date/time filters

### DIFF
--- a/querybuilder.go
+++ b/querybuilder.go
@@ -99,10 +99,31 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 					filter = combine(filter, f)
 				}
 			case "date", "timestamp":
-				f := detectDateComparisonOperator(field, values)
+				var f bson.M
+				if len(values) == 1 {
+					f = detectDateComparisonOperator(field, values)
+				} else {
+					var andFx bson.A
+					for _, value := range values {
+						fx := detectDateComparisonOperator(field, []string{value})
+						andFx = append(andFx, fx)
+					}
+					f = bson.M{"$and": andFx}
+				}
+
 				filter = combine(filter, f)
 			case "decimal", "double", "int", "long":
-				f := detectNumericComparisonOperator(field, values, bsonType)
+				var f bson.M
+				if len(values) == 1 {
+					f = detectNumericComparisonOperator(field, values, bsonType)
+				} else {
+					var andFx bson.A
+					for _, value := range values {
+						fx := detectNumericComparisonOperator(field, []string{value}, bsonType)
+						andFx = append(andFx, fx)
+					}
+					f = bson.M{"$and": andFx}
+				}
 				filter = combine(filter, f)
 			}
 		}

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -89,7 +89,7 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 			}
 
 			switch bsonType {
-			case "array":
+			case "array", "object", "string":
 				f := detectStringComparisonOperator(field, values, bsonType)
 				filter = combine(filter, f)
 			case "bool":
@@ -98,30 +98,11 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 					f := primitive.M{field: bv}
 					filter = combine(filter, f)
 				}
-			case "date":
+			case "date", "timestamp":
 				f := detectDateComparisonOperator(field, values)
 				filter = combine(filter, f)
-			case "decimal":
+			case "decimal", "double", "int", "long":
 				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "double":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "int":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "long":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "object":
-				f := detectStringComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "string":
-				f := detectStringComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "timestamp":
-				// handle just like dates
-				f := detectDateComparisonOperator(field, values)
 				filter = combine(filter, f)
 			}
 		}


### PR DESCRIPTION
This would add an additional feature to the filtration for numeric or date/time fields where the user can filter out results where a given field is between two specified values, e.g.

?filter[price]=<100,>50 [prices ranging from 51-99]
?filter[price=<=1000,>=900 [prices ranging from 900-1000]

etc.

This would be greatly valuable when using the library for filtering products or other fields with numeric attributes that have to fall in a given range, since chaining multiple filter[field]-parameters will only include the last one.

This was the smallest change possible to accomplish this, and will combine the query like follows:

"$and": {
    "field": {"$gte": 400},
    "field": {"$lte": 500}
}

Another option would be to adjust that and instead build it like the following:

"field": {
  "$gte": 400,
  "$lte": 500,
}

Although this would limit the (admittedly not very brilliant) possibility of having multiple operators of the same type (e.g. lte 400 and lte 500), even though the proposed first method is not as clean the syntax is slightly less limiting.