### PR TITLE
building on #7 from the solid work by @scheibling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@
 ### IDE ###
 .vscode
 
+# Testing
+.mongo
+
 # Mac OS
 .DS_Store

--- a/bsonTypes.go
+++ b/bsonTypes.go
@@ -15,35 +15,11 @@ var (
 	reWord = regexp.MustCompile(`\w+`)
 )
 
-func detectDateComparisonOperator(field string, values []string) bson.M {
-	if len(values) == 0 {
-		return nil
+func detectComparisonOperator(value string, isTime bool) (string, string) {
+	oper := ""
+	if len(value) < 2 {
+		return value, oper
 	}
-
-	// if values is greater than 0, use an $in clause
-	if len(values) > 1 {
-		a := bson.A{}
-
-		// add each string value to the bson.A
-		for _, v := range values {
-			dv, _ := time.Parse(time.RFC3339, v)
-			a = append(a, dv)
-		}
-
-		// create a filter with the array of values...
-		filter := bson.M{
-			field: bson.D{primitive.E{
-				Key:   "$in",
-				Value: a,
-			}},
-		}
-
-		// return
-		return filter
-	}
-
-	value := values[0]
-	var oper string
 
 	// check if string value is long enough for a 2 char prefix
 	if len(value) >= 3 {
@@ -89,8 +65,7 @@ func detectDateComparisonOperator(field string, values []string) bson.M {
 			uv = value[1:]
 		}
 
-		// ne
-		if value[0:1] == "-" {
+		if isTime && value[0:1] == "-" {
 			oper = "$ne"
 			uv = value[1:]
 		}
@@ -101,11 +76,64 @@ func detectDateComparisonOperator(field string, values []string) bson.M {
 		}
 	}
 
+	return value, oper
+}
+
+func detectDateComparisonOperator(field string, values []string) bson.M {
+	if len(values) == 0 {
+		return nil
+	}
+
+	// if values is greater than 0, use an $in clause
+	if len(values) > 1 {
+		a := bson.A{}
+		op := false
+
+		// add each string value to the bson.A
+		for _, v := range values {
+			v, oper := detectComparisonOperator(v, false)
+			dv, _ := time.Parse(time.RFC3339, v)
+
+			// if there is an operator, structure the clause to include
+			// the operator
+			if oper != "" {
+				op = true
+				a = append(a, bson.E{
+					Key: field,
+					Value: bson.E{
+						Key:   oper,
+						Value: dv,
+					}})
+				continue
+			}
+
+			a = append(a, dv)
+		}
+
+		// determine type of query
+		if op {
+			return bson.M{
+				"$and": a,
+			}
+		}
+
+		// return a filter with the array of values...
+		return bson.M{
+			field: bson.E{
+				Key:   "$in",
+				Value: a,
+			},
+		}
+	}
+
+	// check for an operator in the value
+	value, oper := detectComparisonOperator(values[0], true)
+
 	// detect usage of keyword "null"
 	if reNull.MatchString(value) {
 		// check if there is an lt, lte, gt or gte key
 		if oper != "" {
-			return bson.M{field: bson.D{primitive.E{
+			return bson.M{field: bson.D{bson.E{
 				Key:   oper,
 				Value: nil,
 			}}}
@@ -120,10 +148,10 @@ func detectDateComparisonOperator(field string, values []string) bson.M {
 
 	// check if there is an lt, lte, gt or gte key
 	if oper != "" {
-		return bson.M{field: bson.D{primitive.E{
+		return bson.M{field: bson.E{
 			Key:   oper,
 			Value: dv,
-		}}}
+		}}
 	}
 
 	// return the filter
@@ -152,8 +180,11 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 	// handle when values is an array
 	if len(values) > 1 {
 		a := bson.A{}
+		op := false
 
 		for _, value := range values {
+			value, oper := detectComparisonOperator(value, false)
+
 			var pv interface{}
 			if numericType == "decimal" || numericType == "double" {
 				v, _ := strconv.ParseFloat(value, bitSize)
@@ -163,7 +194,9 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 				if bitSize == 32 {
 					pv = float32(v)
 				}
-			} else {
+			}
+
+			if pv == nil {
 				v, _ := strconv.ParseInt(value, 0, bitSize)
 				pv = v
 
@@ -173,84 +206,61 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 				}
 			}
 
+			// if there is an operator, structure the clause to include
+			// the operator
+			if oper != "" {
+				op = true
+				a = append(a, bson.E{
+					Key: field,
+					Value: bson.E{
+						Key:   oper,
+						Value: pv,
+					}})
+				continue
+			}
+
+			// otherwise, just add the item to the list
+			// TODO: lots of testing required here...
+			// may need to add an operator when one isn't present
+			// because the mongo query may be incorrect otherwise
 			a = append(a, pv)
+		}
+
+		// determine type of query
+		if op {
+			return bson.M{
+				"$and": a,
+			}
 		}
 
 		// return a filter with the array of values...
 		return bson.M{
-			field: bson.D{primitive.E{
+			field: bson.E{
 				Key:   "$in",
 				Value: a,
-			}},
+			},
 		}
 	}
 
-	var oper string
-	value := values[0]
-
-	// check if string value is long enough for a 2 char prefix
-	if len(value) >= 3 {
-		var uv string
-
-		// lte
-		if value[0:2] == "<=" {
-			oper = "$lte"
-			uv = value[2:]
-		}
-
-		// gte
-		if value[0:2] == ">=" {
-			oper = "$gte"
-			uv = value[2:]
-		}
-
-		// ne
-		if value[0:2] == "!=" {
-			oper = "$ne"
-			uv = value[2:]
-		}
-
-		// update value to remove the prefix
-		if uv != "" {
-			value = uv
-		}
-	}
-
-	// check if string value is long enough for a single char prefix
-	if len(value) >= 2 {
-		var uv string
-
-		// lt
-		if value[0:1] == "<" {
-			oper = "$lt"
-			uv = value[1:]
-		}
-
-		// gt
-		if value[0:1] == ">" {
-			oper = "$gt"
-			uv = value[1:]
-		}
-
-		// update value to remove the prefix
-		if uv != "" {
-			value = uv
-		}
-	}
+	// check for an operator in the value
+	value, oper := detectComparisonOperator(values[0], false)
 
 	if reNull.MatchString(value) {
-		// detect $ne operator (note use of - shorthand here which is not
-		// processed on numeric values that are not "null")
-		if value[0:1] == "-" || value[0:2] == "!=" {
+		// aditionally detect $ne operator (note use of - shorthand here which
+		// is not processed on numeric values that are not "null")... note: this
+		// is detected here and not in the detectComparisonOperator because
+		// numeric values with a prefix of "-" have meaning that is not the same
+		// as an $ne comparison operator
+		if value[0:1] == "-" {
 			oper = "$ne"
 		}
 
 		if oper != "" {
 			// return with the specified operator
-			return bson.M{field: bson.D{primitive.E{
+			return bson.M{field: bson.E{
 				Key:   oper,
 				Value: nil,
-			}}}
+			}}
 		}
 
 		return bson.M{field: nil}
@@ -281,10 +291,10 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 	// check if there is an lt, lte, gt or gte key
 	if oper != "" {
 		// return with the specified operator
-		return bson.M{field: bson.D{primitive.E{
+		return bson.M{field: bson.E{
 			Key:   oper,
 			Value: parsedValue,
-		}}}
+		}}
 	}
 
 	// no operator... just the value
@@ -317,10 +327,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 			}
 
 			fn = fmt.Sprintf("%s.%s", field, fn)
-			filter[fn] = bson.D{primitive.E{
+			filter[fn] = bson.E{
 				Key:   "$exists",
 				Value: exists,
-			}}
+			}
 		}
 
 		return filter
@@ -341,10 +351,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 		}
 
 		// create a filter with the array of values using an $in operator for strings...
-		return bson.M{field: bson.D{primitive.E{
+		return bson.M{field: bson.E{
 			Key:   "$in",
 			Value: a,
-		}}}
+		}}
 	}
 
 	// single value
@@ -401,10 +411,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 	// handle null keyword
 	if reNull.MatchString(value) {
 		if ne {
-			return bson.M{field: bson.D{primitive.E{
+			return bson.M{field: bson.E{
 				Key:   "$ne",
 				Value: nil,
-			}}}
+			}}
 		}
 
 		return bson.M{field: nil}
@@ -412,10 +422,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 
 	// not equal...
 	if ne {
-		return bson.M{field: bson.D{primitive.E{
+		return bson.M{field: bson.E{
 			Key:   "$ne",
 			Value: value,
-		}}}
+		}}
 	}
 
 	// contains...
@@ -456,6 +466,30 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 
 func combine(a bson.M, b bson.M) bson.M {
 	for k, v := range b {
+		// check for existing key
+		if ev, ok := a[k]; ok {
+			// check if existing value is a bson.M
+			if evm, ok := ev.(bson.M); ok {
+				// check if new value is a bson.M
+				if vm, ok := v.(bson.M); ok {
+					// combine the two bson.M values
+					a[k] = combine(evm, vm)
+					continue
+				}
+			}
+
+			// check if existing value is a bson.A
+			if eva, ok := ev.(bson.A); ok {
+				// check if new value is a bson.A
+				if va, ok := v.(bson.A); ok {
+					// combine the two bson.A values by appending each element
+					// from the second array to the first
+					a[k] = append(eva, va...)
+					continue
+				}
+			}
+		}
+
 		a[k] = v
 	}
 

--- a/bsonTypes.go
+++ b/bsonTypes.go
@@ -99,12 +99,12 @@ func detectDateComparisonOperator(field string, values []string, lo LogicalOpera
 			// the operator
 			if oper != "" {
 				op = true
-				a = append(a, bson.E{
+				a = append(a, bson.D{bson.E{
 					Key: field,
-					Value: bson.E{
+					Value: bson.D{bson.E{
 						Key:   oper,
 						Value: dv,
-					}})
+					}}}})
 				continue
 			}
 
@@ -115,13 +115,13 @@ func detectDateComparisonOperator(field string, values []string, lo LogicalOpera
 		if op {
 			// add any $in elements to the outer clause
 			if len(ina) > 0 {
-				a = append(a, bson.E{
+				a = append(a, bson.D{bson.E{
 					Key: field,
-					Value: bson.E{
+					Value: bson.D{bson.E{
 						Key:   "$in",
 						Value: ina,
-					},
-				})
+					}},
+				}})
 			}
 
 			return bson.M{
@@ -131,10 +131,10 @@ func detectDateComparisonOperator(field string, values []string, lo LogicalOpera
 
 		// return a filter with the array of values...
 		return bson.M{
-			field: bson.E{
+			field: bson.D{bson.E{
 				Key:   "$in",
 				Value: ina,
-			},
+			}},
 		}
 	}
 
@@ -145,10 +145,10 @@ func detectDateComparisonOperator(field string, values []string, lo LogicalOpera
 	if reNull.MatchString(value) {
 		// check if there is an lt, lte, gt or gte key
 		if oper != "" {
-			return bson.M{field: bson.E{
+			return bson.M{field: bson.D{bson.E{
 				Key:   oper,
 				Value: nil,
-			}}
+			}}}
 		}
 
 		// return the filter
@@ -160,10 +160,10 @@ func detectDateComparisonOperator(field string, values []string, lo LogicalOpera
 
 	// check if there is an lt, lte, gt or gte key
 	if oper != "" {
-		return bson.M{field: bson.E{
+		return bson.M{field: bson.D{bson.E{
 			Key:   oper,
 			Value: dv,
-		}}
+		}}}
 	}
 
 	// return the filter
@@ -223,12 +223,12 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 			// the operator
 			if oper != "" {
 				op = true
-				a = append(a, bson.E{
+				a = append(a, bson.D{bson.E{
 					Key: field,
-					Value: bson.E{
+					Value: bson.D{bson.E{
 						Key:   oper,
 						Value: pv,
-					}})
+					}}}})
 				continue
 			}
 
@@ -243,13 +243,13 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 		if op {
 			// add any $in elements to the outer clause
 			if len(ina) > 0 {
-				a = append(a, bson.E{
+				a = append(a, bson.D{bson.E{
 					Key: field,
-					Value: bson.E{
+					Value: bson.D{bson.E{
 						Key:   "$in",
 						Value: ina,
-					},
-				})
+					}},
+				}})
 			}
 
 			return bson.M{
@@ -259,10 +259,10 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 
 		// return a filter with the array of values...
 		return bson.M{
-			field: bson.E{
+			field: bson.D{bson.E{
 				Key:   "$in",
 				Value: ina,
-			},
+			}},
 		}
 	}
 
@@ -281,10 +281,10 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 
 		if oper != "" {
 			// return with the specified operator
-			return bson.M{field: bson.E{
+			return bson.M{field: bson.D{bson.E{
 				Key:   oper,
 				Value: nil,
-			}}
+			}}}
 		}
 
 		return bson.M{field: nil}
@@ -315,10 +315,10 @@ func detectNumericComparisonOperator(field string, values []string, numericType 
 	// check if there is an lt, lte, gt or gte key
 	if oper != "" {
 		// return with the specified operator
-		return bson.M{field: bson.E{
+		return bson.M{field: bson.D{bson.E{
 			Key:   oper,
 			Value: parsedValue,
-		}}
+		}}}
 	}
 
 	// no operator... just the value
@@ -351,10 +351,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 			}
 
 			fn = fmt.Sprintf("%s.%s", field, fn)
-			filter[fn] = bson.E{
+			filter[fn] = bson.D{bson.E{
 				Key:   "$exists",
 				Value: exists,
-			}
+			}}
 		}
 
 		return filter
@@ -375,10 +375,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 		}
 
 		// create a filter with the array of values using an $in operator for strings...
-		return bson.M{field: bson.E{
+		return bson.M{field: bson.D{bson.E{
 			Key:   "$in",
 			Value: a,
-		}}
+		}}}
 	}
 
 	// single value
@@ -435,10 +435,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 	// handle null keyword
 	if reNull.MatchString(value) {
 		if ne {
-			return bson.M{field: bson.E{
+			return bson.M{field: bson.D{bson.E{
 				Key:   "$ne",
 				Value: nil,
-			}}
+			}}}
 		}
 
 		return bson.M{field: nil}
@@ -446,10 +446,10 @@ func detectStringComparisonOperator(field string, values []string, bsonType stri
 
 	// not equal...
 	if ne {
-		return bson.M{field: bson.E{
+		return bson.M{field: bson.D{bson.E{
 			Key:   "$ne",
 			Value: value,
-		}}
+		}}}
 	}
 
 	// contains...

--- a/examples/example.go
+++ b/examples/example.go
@@ -11,7 +11,6 @@
 // `curl http://localhost:8080/v1/things?filter[attributes]=round`
 //
 // For more queryoptions info, see: https://github.com/jtlabsio/query
-//
 package main
 
 import (
@@ -69,7 +68,7 @@ type thing struct {
 // create a new MongoDB QueryBuilder (with strict validation set to true)
 var builder = mongobuilder.NewQueryBuilder("things", thingsSchema, true)
 
-//pointer for the mongo collection to query from
+// pointer for the mongo collection to query from
 var collection *mongo.Collection
 
 func getThings(w http.ResponseWriter, r *http.Request) {

--- a/logicalOperators.go
+++ b/logicalOperators.go
@@ -1,0 +1,25 @@
+package querybuilder
+
+type LogicalOperator int
+
+const (
+	And LogicalOperator = iota // $and
+	Not                        // $not
+	Nor                        // $nor
+	Or                         // $or
+)
+
+func (lo LogicalOperator) String() string {
+	switch lo {
+	case And:
+		return "$and"
+	case Not:
+		return "$not"
+	case Nor:
+		return "$nor"
+	case Or:
+		return "$or"
+	default:
+		return ""
+	}
+}

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -71,8 +71,13 @@ func NewQueryBuilder(collection string, schema bson.M, strictValidation ...bool)
 // * javascriptWithScope
 // * minKey
 // * maxKey
-func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
+func (qb QueryBuilder) Filter(qo queryoptions.Options, o ...LogicalOperator) (bson.M, error) {
 	filter := bson.M{}
+	oper := And
+
+	if len(o) > 0 {
+		oper = o[0]
+	}
 
 	if len(qo.Filter) > 0 {
 		for field, values := range qo.Filter {
@@ -99,10 +104,10 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 					filter = combine(filter, f)
 				}
 			case "date", "timestamp":
-				f := detectDateComparisonOperator(field, values)
+				f := detectDateComparisonOperator(field, values, oper)
 				filter = combine(filter, f)
 			case "decimal", "double", "int", "long":
-				f := detectNumericComparisonOperator(field, values, bsonType)
+				f := detectNumericComparisonOperator(field, values, bsonType, oper)
 				filter = combine(filter, f)
 			}
 		}

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -89,7 +89,7 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 			}
 
 			switch bsonType {
-			case "array":
+			case "array", "object", "string":
 				f := detectStringComparisonOperator(field, values, bsonType)
 				filter = combine(filter, f)
 			case "bool":
@@ -98,30 +98,11 @@ func (qb QueryBuilder) Filter(qo queryoptions.Options) (bson.M, error) {
 					f := primitive.M{field: bv}
 					filter = combine(filter, f)
 				}
-			case "date":
+			case "date", "timestamp":
 				f := detectDateComparisonOperator(field, values)
 				filter = combine(filter, f)
-			case "decimal":
+			case "decimal", "double", "int", "long":
 				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "double":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "int":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "long":
-				f := detectNumericComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "object":
-				f := detectStringComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "string":
-				f := detectStringComparisonOperator(field, values, bsonType)
-				filter = combine(filter, f)
-			case "timestamp":
-				// handle just like dates
-				f := detectDateComparisonOperator(field, values)
 				filter = combine(filter, f)
 			}
 		}

--- a/querybuilder_test.go
+++ b/querybuilder_test.go
@@ -262,14 +262,14 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[iVal1]=1,2,3,4,5&filter[iVal2]=1.1,2.2,3.3",
 			},
 			want: bson.M{
-				"iVal1": bson.D{primitive.E{
+				"iVal1": bson.E{
 					Key:   "$in",
-					Value: primitive.A{int32(1), int32(2), int32(3), int32(4), int32(5)},
-				}},
-				"iVal2": bson.D{primitive.E{
+					Value: bson.A{int32(1), int32(2), int32(3), int32(4), int32(5)},
+				},
+				"iVal2": bson.E{
 					Key:   "$in",
-					Value: primitive.A{float32(1.1), float32(2.2), float32(3.3)},
-				}},
+					Value: bson.A{float32(1.1), float32(2.2), float32(3.3)},
+				},
 			},
 			wantErr: false,
 		},
@@ -290,26 +290,26 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[iVal1]=%3C4&filter[iVal2]=%3C%3D3&filter[iVal3]=%3E1&filter[iVal4]=%3E%3D2&filter[iVal5]=%21%3D5",
 			},
 			want: bson.M{
-				"iVal1": bson.D{primitive.E{
+				"iVal1": bson.E{
 					Key:   "$lt",
 					Value: int32(4),
-				}},
-				"iVal2": bson.D{primitive.E{
+				},
+				"iVal2": bson.E{
 					Key:   "$lte",
 					Value: int32(3),
-				}},
-				"iVal3": bson.D{primitive.E{
+				},
+				"iVal3": bson.E{
 					Key:   "$gt",
 					Value: int32(1),
-				}},
-				"iVal4": bson.D{primitive.E{
+				},
+				"iVal4": bson.E{
 					Key:   "$gte",
 					Value: int32(2),
-				}},
-				"iVal5": bson.D{primitive.E{
+				},
+				"iVal5": bson.E{
 					Key:   "$ne",
 					Value: int32(5),
-				}},
+				},
 			},
 			wantErr: false,
 		},
@@ -349,10 +349,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			want: bson.M{
 				"dVal1": time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 				"dVal2": time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				"dVal3": bson.D{primitive.E{
+				"dVal3": bson.E{
 					Key:   "$in",
-					Value: primitive.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
-				}},
+					Value: bson.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
+				},
 			},
 			wantErr: false,
 		},
@@ -374,30 +374,30 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[dVal1]=<2020-01-01T12:00:00.000Z&filter[dVal2]=<=2021-02-16T02:04:05.000Z&filter[dVal3]=>2021-02-16T02:04:05.000Z&filter[dVal4]=>=2021-02-16T02:04:05.000Z&filter[dVal5]=!=2020-01-01T12:00:00.000Z&filter[dVal6]=-2020-01-01T12:00:00.000Z",
 			},
 			want: bson.M{
-				"dVal1": bson.D{primitive.E{
+				"dVal1": bson.E{
 					Key:   "$lt",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				}},
-				"dVal2": bson.D{primitive.E{
+				},
+				"dVal2": bson.E{
 					Key:   "$lte",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				}},
-				"dVal3": bson.D{primitive.E{
+				},
+				"dVal3": bson.E{
 					Key:   "$gt",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				}},
-				"dVal4": bson.D{primitive.E{
+				},
+				"dVal4": bson.E{
 					Key:   "$gte",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				}},
-				"dVal5": bson.D{primitive.E{
+				},
+				"dVal5": bson.E{
 					Key:   "$ne",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				}},
-				"dVal6": bson.D{primitive.E{
+				},
+				"dVal6": bson.E{
 					Key:   "$ne",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				}},
+				},
 			},
 			wantErr: false,
 		},
@@ -418,10 +418,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			want: bson.M{
 				"dVal1": time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 				"dVal2": time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				"dVal3": bson.D{primitive.E{
+				"dVal3": bson.E{
 					Key:   "$in",
-					Value: primitive.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
-				}},
+					Value: bson.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
+				},
 			},
 			wantErr: false,
 		},
@@ -441,18 +441,18 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[oVal]=sVal1,!=sVal2,-sVal3",
 			},
 			want: bson.M{
-				"oVal.sVal1": bson.D{primitive.E{
+				"oVal.sVal1": bson.E{
 					Key:   "$exists",
 					Value: true,
-				}},
-				"oVal.sVal2": bson.D{primitive.E{
+				},
+				"oVal.sVal2": bson.E{
 					Key:   "$exists",
 					Value: false,
-				}},
-				"oVal.sVal3": bson.D{primitive.E{
+				},
+				"oVal.sVal3": bson.E{
 					Key:   "$exists",
 					Value: false,
-				}},
+				},
 			},
 			wantErr: false,
 		},
@@ -469,10 +469,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[sVal1]=value1,value2,value3",
 			},
 			want: bson.M{
-				"sVal1": bson.D{primitive.E{
+				"sVal1": bson.E{
 					Key:   "$in",
-					Value: primitive.A{"value1", "value2", "value3"},
-				}},
+					Value: bson.A{"value1", "value2", "value3"},
+				},
 			},
 			wantErr: false,
 		},
@@ -489,7 +489,7 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[aVal1]=value1,value2,value3",
 			},
 			want: bson.M{
-				"aVal1": primitive.A{"value1", "value2", "value3"},
+				"aVal1": bson.A{"value1", "value2", "value3"},
 			},
 			wantErr: false,
 		},
@@ -525,18 +525,18 @@ func TestQueryBuilder_Filter(t *testing.T) {
 					Options: "i",
 				},
 				"sVal4": "value",
-				"sVal5": bson.D{primitive.E{
+				"sVal5": bson.E{
 					Key:   "$ne",
 					Value: "value",
-				}},
+				},
 				"sVal6": primitive.Regex{
 					Pattern: "^value$",
 					Options: "",
 				},
-				"sVal7": bson.D{primitive.E{
+				"sVal7": bson.E{
 					Key:   "$ne",
 					Value: "value",
-				}},
+				},
 			},
 			wantErr: false,
 		},
@@ -557,15 +557,69 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"sVal1": nil,
-				"nVal1": bson.D{primitive.E{
+				"nVal1": bson.E{
 					Key:   "$ne",
 					Value: nil,
-				}},
+				},
 				"dVal1": nil,
-				"sVal2": bson.D{primitive.E{
+				"sVal2": bson.E{
 					Key:   "$ne",
 					Value: nil,
-				}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "should properly handle numeric values with comparison operators and use $and clause instead of $in",
+			fields: fields{
+				collection: "test",
+				fieldTypes: map[string]string{
+					"iVal1": "int",
+					"iVal2": "decimal",
+				},
+				strictValidation: false,
+			},
+			args: args{
+				qs: "filter[iVal1]=>=1,<5,!=3&filter[iVal2]=>1.1,<=2.2",
+			},
+			want: bson.M{
+				"$and": bson.A{
+					bson.E{
+						Key: "iVal1",
+						Value: bson.E{
+							Key:   "$gte",
+							Value: int32(1),
+						},
+					},
+					bson.E{
+						Key: "iVal1",
+						Value: bson.E{
+							Key:   "$lt",
+							Value: int32(5),
+						},
+					},
+					bson.E{
+						Key: "iVal1",
+						Value: bson.E{
+							Key:   "$ne",
+							Value: int32(3),
+						},
+					},
+					bson.E{
+						Key: "iVal2",
+						Value: bson.E{
+							Key:   "$gt",
+							Value: float32(1.1),
+						},
+					},
+					bson.E{
+						Key: "iVal2",
+						Value: bson.E{
+							Key:   "$lte",
+							Value: float32(2.2),
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -593,7 +647,12 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			// check to see if it matches expectations
 			if !reflect.DeepEqual(got, tt.want) {
 				// values do not match
-				t.Errorf("QueryBuilder.Filter() = %v, want %v", got, tt.want)
+				t.Errorf("QueryBuilder.Filter() = \n%v\n, want \n%v", got, tt.want)
+
+				/*
+					jsn, _ := json.MarshalIndent(got, "", "  ")
+					t.Logf("got: %s", jsn)
+					//*/
 			}
 		})
 	}

--- a/querybuilder_test.go
+++ b/querybuilder_test.go
@@ -1,7 +1,6 @@
 package querybuilder
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -264,14 +263,14 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[iVal1]=1,2,3,4,5&filter[iVal2]=1.1,2.2,3.3",
 			},
 			want: bson.M{
-				"iVal1": bson.E{
+				"iVal1": bson.D{bson.E{
 					Key:   "$in",
 					Value: bson.A{int32(1), int32(2), int32(3), int32(4), int32(5)},
-				},
-				"iVal2": bson.E{
+				}},
+				"iVal2": bson.D{bson.E{
 					Key:   "$in",
 					Value: bson.A{float32(1.1), float32(2.2), float32(3.3)},
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -292,26 +291,26 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[iVal1]=%3C4&filter[iVal2]=%3C%3D3&filter[iVal3]=%3E1&filter[iVal4]=%3E%3D2&filter[iVal5]=%21%3D5",
 			},
 			want: bson.M{
-				"iVal1": bson.E{
+				"iVal1": bson.D{bson.E{
 					Key:   "$lt",
 					Value: int32(4),
-				},
-				"iVal2": bson.E{
+				}},
+				"iVal2": bson.D{bson.E{
 					Key:   "$lte",
 					Value: int32(3),
-				},
-				"iVal3": bson.E{
+				}},
+				"iVal3": bson.D{bson.E{
 					Key:   "$gt",
 					Value: int32(1),
-				},
-				"iVal4": bson.E{
+				}},
+				"iVal4": bson.D{bson.E{
 					Key:   "$gte",
 					Value: int32(2),
-				},
-				"iVal5": bson.E{
+				}},
+				"iVal5": bson.D{bson.E{
 					Key:   "$ne",
 					Value: int32(5),
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -351,10 +350,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			want: bson.M{
 				"dVal1": time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 				"dVal2": time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				"dVal3": bson.E{
+				"dVal3": bson.D{bson.E{
 					Key:   "$in",
 					Value: bson.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -377,34 +376,34 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[dVal1]=<2020-01-01T12:00:00.000Z&filter[dVal2]=<=2021-02-16T02:04:05.000Z&filter[dVal3]=>2021-02-16T02:04:05.000Z&filter[dVal4]=>=2021-02-16T02:04:05.000Z&filter[dVal5]=!=2020-01-01T12:00:00.000Z&filter[dVal6]=-2020-01-01T12:00:00.000Z&filter[dVal7]=!=null",
 			},
 			want: bson.M{
-				"dVal1": bson.E{
+				"dVal1": bson.D{bson.E{
 					Key:   "$lt",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				},
-				"dVal2": bson.E{
+				}},
+				"dVal2": bson.D{bson.E{
 					Key:   "$lte",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				},
-				"dVal3": bson.E{
+				}},
+				"dVal3": bson.D{bson.E{
 					Key:   "$gt",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				},
-				"dVal4": bson.E{
+				}},
+				"dVal4": bson.D{bson.E{
 					Key:   "$gte",
 					Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				},
-				"dVal5": bson.E{
+				}},
+				"dVal5": bson.D{bson.E{
 					Key:   "$ne",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				},
-				"dVal6": bson.E{
+				}},
+				"dVal6": bson.D{bson.E{
 					Key:   "$ne",
 					Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-				},
-				"dVal7": bson.E{
+				}},
+				"dVal7": bson.D{bson.E{
 					Key:   "$ne",
 					Value: nil,
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -425,10 +424,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			want: bson.M{
 				"dVal1": time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 				"dVal2": time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-				"dVal3": bson.E{
+				"dVal3": bson.D{bson.E{
 					Key:   "$in",
 					Value: bson.A{time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC), time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)},
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -448,18 +447,18 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[oVal]=sVal1,!=sVal2,-sVal3",
 			},
 			want: bson.M{
-				"oVal.sVal1": bson.E{
+				"oVal.sVal1": bson.D{bson.E{
 					Key:   "$exists",
 					Value: true,
-				},
-				"oVal.sVal2": bson.E{
+				}},
+				"oVal.sVal2": bson.D{bson.E{
 					Key:   "$exists",
 					Value: false,
-				},
-				"oVal.sVal3": bson.E{
+				}},
+				"oVal.sVal3": bson.D{bson.E{
 					Key:   "$exists",
 					Value: false,
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -476,10 +475,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				qs: "filter[sVal1]=value1,value2,value3",
 			},
 			want: bson.M{
-				"sVal1": bson.E{
+				"sVal1": bson.D{bson.E{
 					Key:   "$in",
 					Value: bson.A{"value1", "value2", "value3"},
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -532,18 +531,18 @@ func TestQueryBuilder_Filter(t *testing.T) {
 					Options: "i",
 				},
 				"sVal4": "value",
-				"sVal5": bson.E{
+				"sVal5": bson.D{bson.E{
 					Key:   "$ne",
 					Value: "value",
-				},
+				}},
 				"sVal6": primitive.Regex{
 					Pattern: "^value$",
 					Options: "",
 				},
-				"sVal7": bson.E{
+				"sVal7": bson.D{bson.E{
 					Key:   "$ne",
 					Value: "value",
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -564,15 +563,15 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"sVal1": nil,
-				"nVal1": bson.E{
+				"nVal1": bson.D{bson.E{
 					Key:   "$ne",
 					Value: nil,
-				},
+				}},
 				"dVal1": nil,
-				"sVal2": bson.E{
+				"sVal2": bson.D{bson.E{
 					Key:   "$ne",
 					Value: nil,
-				},
+				}},
 			},
 			wantErr: false,
 		},
@@ -591,41 +590,41 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"$and": bson.A{
-					bson.E{
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gte",
 							Value: int32(1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lt",
 							Value: int32(5),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$ne",
 							Value: int32(3),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gt",
 							Value: float32(1.1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lte",
 							Value: float32(2.2),
-						},
-					},
+						}},
+					}},
 				},
 			},
 			wantErr: false,
@@ -644,27 +643,27 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"$and": bson.A{
-					bson.E{
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gt",
 							Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lte",
 							Value: time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$ne",
 							Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-						},
-					},
+						}},
+					}},
 				},
 			},
 			wantErr: false,
@@ -684,62 +683,62 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"$and": bson.A{
-					bson.E{
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gte",
 							Value: int32(1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lt",
 							Value: int32(5),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$ne",
 							Value: int32(3),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key: "$in",
 							Value: bson.A{
 								int32(2),
 								int32(4),
 							},
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gt",
 							Value: float32(1.1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lte",
 							Value: float32(2.2),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key: "$in",
 							Value: bson.A{
 								float32(1.3),
 								float32(1.4),
 								float32(1.5),
 							},
-						},
-					},
+						}},
+					}},
 				},
 			},
 			wantErr: false,
@@ -758,37 +757,37 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"$and": bson.A{
-					bson.E{
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gt",
 							Value: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lte",
 							Value: time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$ne",
 							Value: time.Date(2021, time.February, 16, 2, 4, 5, 0, time.UTC),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "dVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key: "$in",
 							Value: bson.A{
 								time.Date(2021, time.February, 16, 1, 1, 0, 0, time.UTC),
 								time.Date(2021, time.February, 16, 2, 1, 0, 0, time.UTC),
 							},
-						},
-					},
+						}},
+					}},
 				},
 			},
 			wantErr: false,
@@ -811,41 +810,41 @@ func TestQueryBuilder_Filter(t *testing.T) {
 			},
 			want: bson.M{
 				"$or": bson.A{
-					bson.E{
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gte",
 							Value: int32(1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lt",
 							Value: int32(5),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal1",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$ne",
 							Value: int32(3),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$gt",
 							Value: float32(1.1),
-						},
-					},
-					bson.E{
+						}},
+					}},
+					bson.D{bson.E{
 						Key: "iVal2",
-						Value: bson.E{
+						Value: bson.D{bson.E{
 							Key:   "$lte",
 							Value: float32(2.2),
-						},
-					},
+						}},
+					}},
 				},
 			},
 			wantErr: false,
@@ -876,10 +875,10 @@ func TestQueryBuilder_Filter(t *testing.T) {
 				// values do not match
 				t.Errorf("QueryBuilder.Filter() = \n%v\n, want \n%v", got, tt.want)
 
-				///*
-				jsn, _ := json.MarshalIndent(got, "", "  ")
-				t.Logf("got: %s", jsn)
-				//*/
+				/*
+					jsn, _ := json.MarshalIndent(got, "", "  ")
+					t.Logf("got: %s", jsn)
+					//*/
 			}
 		})
 	}

--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,32 @@ For `date` bsonType fields in the schema (`date` and `timestamp`), any values in
 * `in` (i.e. `{ "someDate": { "$in": [ ... ] } }`): `?filter[someDate]=2021-02-16T00:00:00.000Z,2021-02-15T00:00:00.000Z`
 * standard comparison (i.e. `{ "someDate": new Date("2021-02-16T02:04:05.000Z") }`): `?filter[someDate]=2021-02-16T02:04:05.000Z`
 
+###### Logical Operators
+
+By default, when one or more query operators are provided via the search querystring, the `QueryBuilder` will construct a `$and` filter with the provided operators. For example:
+
+* `greater than equal` combined with `less than` (i.e. `{ $"and": [ { "age": { "$gte": 18, } }, { "age": { "$lt": 24, } } ] }`): `?filter[age]=>=18,<24`
+
+This behavior can be overridden by providing a LogicalOperator constant as an optional value to the `Filter` method:
+
+```go
+// a query filter in a bson.M based on QueryOptions Filter values
+f, err := builder.Filter(opt, mongobuilder.Or)
+if err != nil {
+	// this only occurs when strict schema validation is true
+	// and a field is named in the querystring that doesn't actually
+	// exist as defined in the schema... this is NOT the default
+	// behavior
+}
+```
+
+There are 4 logical operators that can be used:
+
+* `mongobuilder.And`: `$and`
+* `mongobuilder.Or`: `$or`
+* `mongobuilder.Nor`: `$nor`
+* `mongobuilder.Not`: `$not`
+
 #### FindOptions
 
 Pagination, sorting and field projection are defined in options that are provided via `QueryOptions` can be extracted in used in MongoDB Find calls using the `FindOptions` method:


### PR DESCRIPTION
In this update, there is an added feature that works as follows:

When an array of values is provided for a particular field, an `$in` search is constructed for Mongo:

`?filter[fn]=1,2,3,4`

```json
{
  "fn": { 
    "$in": [1, 2, 3 ,4]
  }
}
```

When expressions / operators are provided on a list of values, an `$and` search is created instead:

`?filter[fn]=>=1,<5,!=3`

```json
{
  "$and": [
    {
      "fn": {
        "$gte": 1
      }
    },
    {
      "fn": {
        "$lt": 5
      }
    },
    {
      "fn": {
        "$ne": 3
      }
    },
  ]
}
```