### PR TITLE
Fix panic when user inputs single dash in sort

### DIFF
--- a/querybuilder.go
+++ b/querybuilder.go
@@ -248,7 +248,7 @@ func (qb QueryBuilder) setProjectionOptions(fields []string, opts *options.FindO
 			}
 
 			// handle scenarios where the first char is a + (redundant)
-			if field[0:1] == "+" {
+			if len(field) > 0 && field[0:1] == "+" {
 				field = field[1:]
 			}
 


### PR DESCRIPTION
Fixes panic crash when user inputs single dash in sort field. It will still return an error, just not kill the entire application